### PR TITLE
When no groupby are specified emit a grain filter.

### DIFF
--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-echarts",
-  "version": "0.17.84-cccs.1",
+  "version": "0.17.84-cccs.2",
   "description": "Superset Chart - Echarts",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -19,7 +19,7 @@
 import React, { useCallback } from 'react';
 import { EventHandlers } from '../types';
 import Echart from '../components/Echart';
-import { TimeseriesChartTransformedProps } from './types';
+import { doesSupportGrainSelection, TimeseriesChartTransformedProps } from './types';
 
 // @ts-ignore
 export default function EchartsTimeseries({
@@ -44,7 +44,7 @@ export default function EchartsTimeseries({
           filters:
             values.length === 0
               ? []
-              : groupby.length === 0
+              : doesSupportGrainSelection(formData.seriesType) && groupby.length === 0
               ? // special case when there are no series
                 // the only value we are given is the time in epoch seconds
                 // create a filter with the grain of the chart

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -52,7 +52,7 @@ export default function EchartsTimeseries({
                   {
                     col: formData.granularitySqla,
                     op: '==',
-                    val: values[0],
+                    val: Number(values[0]),
                     grain: formData.timeGrainSqla,
                   },
                 ]
@@ -82,25 +82,12 @@ export default function EchartsTimeseries({
 
   const eventHandlers: EventHandlers = {
     click: props => {
-      const { seriesName: name, value: arrayOfValuesClicked } = props;
-      // special case when there are no series (nothing in the groupby)
-      // the only aggregation is against the grain
-      // When the user clicks in the chart we get a datatime and metric columns
-      // The first value is the datetime selected
-      const datetime = arrayOfValuesClicked[0];
-
-      let chosenValue = name;
-      if (groupby.length === 0) {
-        // Get the time in seconds epcho, this is the value we will use
-        // in the emit filter.
-        chosenValue = datetime.getTime();
-      }
-
+      const { seriesName: name } = props;
       const values = Object.values(selectedValues);
-      if (values.includes(chosenValue)) {
-        handleChange(values.filter(v => v !== chosenValue));
+      if (values.includes(name)) {
+        handleChange(values.filter(v => v !== name));
       } else {
-        handleChange([chosenValue]);
+        handleChange([name]);
       }
     },
   };

--- a/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -44,6 +44,18 @@ export default function EchartsTimeseries({
           filters:
             values.length === 0
               ? []
+              : groupby.length === 0
+              ? // special case when there are no series
+                // the only value we are given is the time in epoch seconds
+                // create a filter with the grain of the chart
+                [
+                  {
+                    col: formData.granularitySqla,
+                    op: '==',
+                    val: values[0],
+                    grain: formData.timeGrainSqla,
+                  },
+                ]
               : groupby.map((col, idx) => {
                   const val = groupbyValues.map(v => v[idx]);
                   if (val === null || val === undefined)
@@ -70,12 +82,25 @@ export default function EchartsTimeseries({
 
   const eventHandlers: EventHandlers = {
     click: props => {
-      const { seriesName: name } = props;
+      const { seriesName: name, value: arrayOfValuesClicked } = props;
+      // special case when there are no series (nothing in the groupby)
+      // the only aggregation is against the grain
+      // When the user clicks in the chart we get a datatime and metric columns
+      // The first value is the datetime selected
+      const datetime = arrayOfValuesClicked[0];
+
+      let chosenValue = name;
+      if (groupby.length === 0) {
+        // Get the time in seconds epcho, this is the value we will use
+        // in the emit filter.
+        chosenValue = datetime.getTime();
+      }
+
       const values = Object.values(selectedValues);
-      if (values.includes(name)) {
-        handleChange(values.filter(v => v !== name));
+      if (values.includes(chosenValue)) {
+        handleChange(values.filter(v => v !== chosenValue));
       } else {
-        handleChange([name]);
+        handleChange([chosenValue]);
       }
     },
   };

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -32,6 +32,7 @@ import {
 import { EChartsOption, SeriesOption } from 'echarts';
 import {
   DEFAULT_FORM_DATA,
+  doesSupportGrainSelection,
   EchartsTimeseriesChartProps,
   EchartsTimeseriesFormData,
   TimeseriesChartTransformedProps,
@@ -135,7 +136,7 @@ export default function transformProps(
 
   const tooltipFormatter = getTooltipTimeFormatter(tooltipTimeFormat);
 
-  if (groupby.length === 0) {
+  if (doesSupportGrainSelection(seriesType) && groupby.length === 0) {
     // special case when there are no series (nothing in the groupby)
     // the only aggregation is against the grain
     // In that situation we create series for each grain value (for example each month)
@@ -327,7 +328,7 @@ export default function transformProps(
   // In the special case where there is no groupby our series will
   // be the grain values. In this case we only value to display per series
   // we align all the bars to the left.
-  if (groupby.length === 0) {
+  if (doesSupportGrainSelection(seriesType) && groupby.length === 0) {
     echartOptions.barGap = '-100%';
   }
 

--- a/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -144,7 +144,8 @@ export default function transformProps(
     // The name is the value selected and emitted in this case the truncated timestamp in seconds
     // The data is single time/metric pair
     rawSeries.forEach(entry => {
-      entry.data.forEach(datapoint => {
+      const data = entry.data as any[];
+      data.forEach(datapoint => {
         let newEntry = {
           id: `${tooltipFormatter(datapoint[0])}`,
           name: '' + datapoint[0].getTime(),

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -116,3 +116,7 @@ export interface EchartsTimeseriesChartProps extends ChartProps {
 }
 
 export type TimeseriesChartTransformedProps = EChartTransformedProps<EchartsTimeseriesFormData>;
+
+export function doesSupportGrainSelection(type: EchartsTimeseriesSeriesType): boolean {
+  return [EchartsTimeseriesSeriesType.Scatter, EchartsTimeseriesSeriesType.Bar].includes(type);
+}


### PR DESCRIPTION
This PR adds emit filter for echarts that do not groupby any of the columns. In that specific case this PR will emit a filter that targets the grain column, applies the correct truncate of the time (say by month) and equals the value to the chosen time.

https://github.com/apache-superset/superset-ui/issues/1475

