### PR TITLE
Updating plugin-chart-table to a newer version

### DIFF
--- a/plugins/plugin-chart-table/package.json
+++ b/plugins/plugin-chart-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-table",
-  "version": "0.17.84-cccs.2",
+  "version": "0.17.84-cccs.3",
   "description": "Superset Chart - Table",
   "main": "lib/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
A change has been made and the version of the plugin has not been
bumped from cccs.2 to cccs.3, this check-in fixes that.
