### PR TITLE
removed support for multiple row selection

### DIFF
--- a/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/plugins/plugin-chart-table/src/TableChart.tsx
@@ -281,12 +281,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         // filters for metrics are derived from the selectedMetricRows
         updatedFilters = {};
 
-        // add or remove the selected row from selectedMetricRows
+        // replace the selected row from selectedMetricRows
         if (selectedMetricRows.current.some(r => r?.id == row.id)) {
-          const newList = selectedMetricRows.current.filter(r => r.id != row.id);
-          selectedMetricRows.current.splice(0, selectedMetricRows.current.length, ...newList);
+          selectedMetricRows.current = [];
         } else {
-          selectedMetricRows.current.push(row);
+          selectedMetricRows.current = [row];
         }
 
         // update the filters according to the selected rows


### PR DESCRIPTION
the implementation was incorrect

will handle multi row selection with ctrl-click

these should emit filter of the form

(year=2007 AND category='classiccars')
OR
(year=2006 AND category='airplanes')

however this requires more work

